### PR TITLE
handle imported builds

### DIFF
--- a/fedmsg_meta_umb/brew.py
+++ b/fedmsg_meta_umb/brew.py
@@ -53,7 +53,7 @@ class BrewProcessor(BaseProcessor):
             },
             'build': {
                 'building': self._('{info[name]}-{info[version]}-{info[release]} is building'),
-                'complete': self._('{info[nvr]} has been built successfully'),
+                'complete': self._('{info[name]}-{info[version]}-{info[release]} has been built successfully'),
                 'deleted': self._('{info[nvr]} has been deleted'),
                 'failed': self._('build of {info[nvr]} has failed'),
                 'canceled': self._('build of {info[nvr]} has been canceled'),
@@ -113,7 +113,9 @@ class BrewProcessor(BaseProcessor):
                 return set([msg['msg']['user']['name'],
                             msg['msg']['build']['owner_name']])
             else:
-                return set([msg['msg']['info']['owner_name']])
+                owner_name = msg['msg']['info'].get('owner_name')
+                if owner_name:
+                    return set([owner_name])
         elif tokens[-2] == 'import':
             return set([msg['msg']['build']['owner_name']])
         elif tokens[-2] == 'sign':

--- a/fedmsg_meta_umb/tests/test_brew_build.py
+++ b/fedmsg_meta_umb/tests/test_brew_build.py
@@ -95,6 +95,41 @@ class TestBrewBuildComplete(test_brew.BrewBase):
         }
     }
 
+class TestBrewBuildCompleteDocker(test_brew.BrewBase):
+    expected_title = 'brew.build.complete'
+    expected_subti = 'metrics-cassandra-docker-3.6.0-3 has been built successfully'
+    expected_packages = set(['metrics-cassandra-docker'])
+    expected_usernames = set()
+    expected_link = 'https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=550925'
+    msg = {
+        "i": 0,
+        "timestamp": 1491951183.0,
+        "msg_id": "ffcbdc40-1435-492f-83f9-51b9892b9524",
+        "topic": "/topic/VirtualTopic.eng.brew.build.complete",
+        "msg": {
+            "info": {
+                "start_time": "2017-04-11 22:42:53",
+                "name": "metrics-cassandra-docker",
+                "task_id": None,
+                "extra": "{\"image\": {\"autorebuild\": false, \"help\": null}, \"container_koji_task_id\": 12996137}",
+                "pkg_id": 54389,
+                "state": 1,
+                "completion_time": "2017-04-11 22:52:49",
+                "epoch": None,
+                "version": "3.6.0",
+                "source": "git://pkgs.devel.redhat.com/rpms/metrics-cassandra-docker#"
+                "1c9ebc26c5066ed4894d45878bc90fd66046a292",
+                "volume_id": 0,
+                "owner": 3436,
+                "release": "3",
+                "id": 550925
+            },
+            "attribute": "state",
+            "old": None,
+            "new": 1
+        }
+    }
+
 class TestBrewBuildDeleted(test_brew.BrewBase):
     expected_title = 'brew.build.deleted'
     expected_subti = 'elasticsearch-2.4.1-2.el7 has been deleted'


### PR DESCRIPTION
Builds that have been imported send messages with fewer fields defined.
Specifically, info['nvr'] and info['owner_name'] are missing. Update
the code to handle these messages gracefully.