### PR TITLE
more CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
  - "2.7"
+ - "3.5"
 install: python setup.py develop
 script:
  - python setup.py flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,5 @@ language: python
 python:
  - "2.7"
  - "3.5"
-install: python setup.py develop
-script:
- - python setup.py flake8
- - python setup.py test
+install: pip install tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+sudo: false
 language: python
 python:
  - "2.7"
  - "3.5"
-install: pip install tox-travis
-script: tox
+install: pip install tox-travis codecov
+script: tox -- --with-coverage --cover-branches --cover-package=fedmsg_meta_umb
+               --cover-xml --cover-xml-file=$TRAVIS_BUILD_DIR/coverage.xml
+after_success: codecov -e TRAVIS_PYTHON_VERSION --file $TRAVIS_BUILD_DIR/coverage.xml

--- a/README.rst
+++ b/README.rst
@@ -24,11 +24,15 @@ Build Status
    :alt: Build Status - master branch
    :target: http://travis-ci.org/#!/release-engineering/fedmsg_meta_umb
 
-+----------+-----------+
-| Branch   | Status    |
-+==========+===========+
-| master   | |master|  |
-+----------+-----------+
+.. |codecov| image:: https://codecov.io/gh/release-engineering/fedmsg_meta_umb/branch/master/graph/badge.svg
+   :alt: Code Coverage - master branch
+   :target: https://codecov.io/gh/release-engineering/fedmsg_meta_umb
+
++----------+-----------+-----------+
+| Branch   | Status    | Coverage  |
++==========+===========+===========+
+| master   | |master|  | |codecov| |
++----------+-----------+-----------+
 
 Running the Tests
 -----------------

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ basepython =
 deps =
     fedmsg
     nose
+    coverage
 sitepackages = False
 commands =
     nosetests {posargs}


### PR DESCRIPTION
Run tests on python 3.5 in Travis CI. Use tox when running tests in Travis CI, for consistency with local testing. Get code coverage reports from codecov.io.