### PR TITLE
Add some datagrepper docs.

### DIFF
--- a/datagrepper-docs/charts.rst
+++ b/datagrepper-docs/charts.rst
@@ -1,0 +1,4 @@
+Charts and Graphs
+=================
+
+... are unsupported.

--- a/datagrepper-docs/index.rst
+++ b/datagrepper-docs/index.rst
@@ -1,0 +1,185 @@
+.. |crarr| unicode:: U+021B5 .. DOWNWARDS ARROW WITH CORNER LEFTWARDS
+
+Prerequisites
+-------------
+
+If you've never interacted with a JSON API before, you should check out
+the handy command-line tool `HTTPie
+<https://github.com/jkbr/httpie#httpie-a-cli-curl-like-tool-for-humans>`_.
+All our examples here will use it.  To install it on Fedora run ``$ sudo
+yum -y install httpie`` (you'll need to enable epel7 on an el7 machine).
+
+If you get stuck here, feel free to drop into the ``#pnt-devops-dev``
+channel on `irc <https://mojo.redhat.com/search.jspa?q=how+to+irc>`_ to
+ask questions or even just to give us a high five if everything goes well.
+
+Requesting all messages in the last 2 days
+------------------------------------------
+
+datagrepper takes all time arguments in `seconds`, so we'll need to
+convert 2 days to 172800 seconds first.  Then we can use `HTTPie
+<https://github.com/jkbr/httpie#httpie-a-cli-curl-like-tool-for-humans>`_
+like this::
+
+    $ http get {{URL}}raw delta==172800
+
+Paging results
+--------------
+
+You're going to get a large JSON response that's too big to read
+through.  Try limiting the number of results to make it more
+digestable::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        rows_per_page==1
+
+.. code-block:: javascript
+
+    {
+        "arguments": {
+            "delta": 1728000.0,
+            "end": 1366221938.0,
+            "page": 1,
+            "rows_per_page": 1,
+            "order": "desc",
+            "start": 1364493938.0,
+            "topics": [],
+            "categories": [],
+            "users": []
+            "packages": [],
+            "not_topics": [],
+            "not_categories": [],
+            "not_users": []
+            "not_packages": [],
+        },
+        "count": 1,
+        "pages": 2052,
+        "raw_messages": [
+            ...
+        ],
+        "total": 2052
+    }
+
+In the above output, the contents of ``raw_messages`` has been omitted for
+readability.  Notice a few things: first, the ``arguments`` dict describes
+all the parameters that datagrepper used to execute your query.  The
+``start`` and ``end`` timestamps are included (they were derived from
+the ``delta`` that you supplied). 
+
+Your ``rows_per_page`` is there.  It has a sibling value ``page`` which
+is a pointer to which "page" of data you are on.  You could issue the
+following query to get the next one::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        rows_per_page==1 \
+        page==2
+
+.. code-block:: javascript
+
+    {
+        "arguments": {
+            "delta": 1728000.0,
+            "end": 1366221938.0,
+            "page": 2,
+            "rows_per_page": 1,
+            "order": "desc",
+            "start": 1364493938.0,
+            "topics": [],
+            "categories": [],
+            "users": []
+            "packages": [],
+            "not_topics": [],
+            "not_categories": [],
+            "not_users": []
+            "not_packages": [],
+        },
+        "count": 1,
+        "pages": 2052,
+        "raw_messages": [
+            ...
+        ],
+        "total": 2052
+    }
+
+
+By default, the order of rows retrieved is from newest to oldest ("descending")
+There is an ``order`` argument you can specify to set that how you like.  The
+default is "desc", but you can set it to "asc" for ascending order, a.k.a.
+from oldest to newest.
+
+Only Errata messages (OR rpmdiff)
+---------------------------------
+
+There are many types of messages messages that come across the Unified Message
+Bus. You can limit the scope of your query to only one kind of message by
+specifying a ``category``::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        category==errata
+
+Note that, in this example, ``category`` is singular but it comes back in
+the ``arguments`` dict as *categories* (plural!)  You can specify more
+than one category and messages that match *either* category will be returned.
+They are **OR**'d together::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        category==errata \
+        category==rpmdiff
+
+Messages for a particular users and packages
+--------------------------------------------
+
+Just like categories, you can search for events relating to one or multiple
+users::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        user==mikeb \
+        user==rbean
+
+Same goes for packages::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        package==nethack
+
+Everything but the...
+---------------------
+
+There are corresponding *negative filters* for each of the above mentioned
+positive filters.  For instance, if you wanted to get all messages **except for
+Brew messages**, you could use this query::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        not_category==brew
+
+You can combine positive and negative filters as you might expect to, for
+instance, get all messages relating to the user tkuratom **except** for dist-git activity::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        user==tkuratom \
+        not_category==distgit
+
+Putting it all together (CNF)
+-----------------------------
+
+If you specify multiple ``category`` filters and multiple ``user`` filters
+and multiple ``package`` filters, they are merged together in a way that looks
+like `Conjunctive Normal Form (CNF)
+<http://en.wikipedia.org/wiki/Conjunctive_normal_form>`_.
+
+For example, this query will return all messages from the past 2 days where
+*(category==errata OR category==brew) AND (user==psabata OR user==bkearney)*::
+
+    $ http get {{URL}}raw \
+        delta==172800 \
+        category==errata \
+        category==brew \
+        user==psabata \
+        user==bkearney

--- a/datagrepper-docs/index.rst
+++ b/datagrepper-docs/index.rst
@@ -104,7 +104,7 @@ following query to get the next one::
     }
 
 
-By default, the order of rows retrieved is from newest to oldest ("descending")
+By default, the order of rows retrieved is from newest to oldest ("descending").
 There is an ``order`` argument you can specify to set that how you like.  The
 default is "desc", but you can set it to "asc" for ascending order, a.k.a.
 from oldest to newest.

--- a/datagrepper-docs/reference.rst
+++ b/datagrepper-docs/reference.rst
@@ -1,0 +1,258 @@
+General API notes
+-----------------
+
+All API calls (currently) permit only GET requests.
+
+A trailing slash is optional on all API endpoints. There is no difference
+between using one and not using one.
+
+Responses can be served as ``application/json`` or ``text/html`` as per the accept header. If the request
+is made in "text/html" then it will return the html content otherwise it will return the json content (unless ``JSONP`` is
+explicitly requested, in which case datagrepper returns the appropriate ``application/javascript``).
+
+
+/raw
+----
+
+The ``/raw`` endpoint returns lists of messages.
+
+Response format
+===============
+
+Sample response:
+
+.. code-block:: javascript
+
+    {
+      "arguments": {
+        "page": 1,
+        "rows_per_page": 20,
+        ...
+      },
+      "count": 1,
+      "pages": 42,
+      "raw_messages": [
+        {
+          "certificate": "...",
+          "i": 1,
+          "msg": {
+            ...
+          },
+          "signature": "...",
+          "timestamp": 1361414385.0,
+          "topic": "/topic/VirtualTopic.eng.example"
+        },
+        ...
+      ],
+      "total": 851
+    }
+
+The ``arguments`` item in the root dictionary contains all possible arguments,
+and displays the value used (the default if the argument was not provided).
+
+Time arguments
+==============
+
+Below is a table describing what timeframe messages are received from
+depending on what combination of time options you provide.
+
+========= ========= ======= =================
+``delta`` ``start`` ``end`` Message timeframe
+========= ========= ======= =================
+no        no        no      last ``rows_per_page`` items
+**yes**   no        no      last ``delta`` seconds
+no        **yes**   no      from ``start`` until now
+**yes**   **yes**   no      from ``start`` until ``delta`` seconds from ``start``
+no        no        **yes** the 600 seconds before ``end``
+**yes**   no        **yes** the ``delta`` seconds before ``end``
+no        **yes**   **yes** between ``start`` and ``end``
+**yes**   **yes**   **yes** between ``start`` and ``end`` (``delta`` is ignored)
+========= ========= ======= =================
+
+
+``delta``
+  Return results from the last ``delta`` seconds.
+
+  Default: None
+
+``start``
+  Return results starting at time ``start`` (in `UNIX time
+  <https://en.wikipedia.org/wiki/Unix_time>`_).
+
+  Default: None or (``end`` minus ``delta``)
+
+``end``
+  Return results ending at time ``end`` (in `UNIX time
+  <https://en.wikipedia.org/wiki/Unix_time>`_).
+
+  Default: None or current
+
+Filter arguments
+================
+
+``user``
+  LDAP user to query for.
+
+  This argument can be provided multiple times; returns messages referring to
+  any listed user.
+
+  Default: all users
+
+``package``
+  dist-git package to query for.
+
+  This argument can be provided multiple times; returns messages referring to
+  any listed package.
+
+  Default: all packages
+
+``category``
+  Category to query for.
+
+  On the UMB, a *category* is what service emitted the message, e.g. ``distgit``,
+  ``errata``, or ``brew``. In the dot-delimited topic, the category is the
+  first entry to appear after `".eng."`.
+
+  This argument can be provided multiple times; returns messages referring to
+  any listed category.
+
+  Default: all categories
+
+``topic``
+  Topic to query for.
+
+  Example: ``/topic/VirtualTopic.eng.distgit.commit``.
+
+  This argument can be provided multiple times; returns messages referring to
+  any listed topic.
+
+  Default: all topics
+
+``contains``
+  Keyword to search in the messages.
+
+  Sometime one knows only a part of a message, this would allow retrieving
+  all the messages containing that part.
+
+  This argument can be provided multiple times; returns messages referring to
+  any listed topic.
+
+  Default: all messages
+
+``not_user``
+  LDAP users to exempt from query.
+
+  This argument can be provided multiple times; returns only messages that do
+  not refer to any listed user.
+
+  Default: no users
+
+``not_package``
+  dist-git package to exempt from query.
+
+  This argument can be provided multiple times; returns only messages that do
+  not refer to any listed package.
+
+  Default: no packages
+
+``not_category``
+  Category to exempt from query.
+
+  On the UMB, a *category* is what service emitted the message, e.g. ``distgit``,
+  ``errata``, or ``brew``. In the dot-delimited topic, the category is the
+  first entry to appear after `".eng."`.
+
+  This argument can be provided multiple times; returns only messages that
+  do not fall under the listed categories.
+
+  Default: no categories
+
+``not_topic``
+  Topic to exempt from query.
+
+  Example: ``/topic/VirtualTopic.eng.distgit.commit``.
+
+  This argument can be provided multiple times; returns only messages that
+  do are not marked with the listed topics.
+
+  Default: no topics
+
+Pagination arguments
+====================
+
+``page``
+  Which page to return. Must be greater than 0.
+
+  Default: 1
+
+``rows_per_page``
+  The number of messages to return for each page. Must be less than or equal to
+  100.
+
+  Default: 20
+
+``order``
+  The "order" in which messages should be returned.  Must be one of either
+  "asc" or "desc".  "asc" means ascending, i.e. from oldest to newest.
+  "desc" means descending, i.e. from newest to oldest.
+
+  Default: "desc"
+
+Formatting arguments
+====================
+
+``callback``
+  To be specified when querying datagrepper via JavaScript/ajax, it will
+  return a "jsonp" output with the MIME type 'application/javascript'
+  instead of the traditionnal "json".
+
+  Default: None
+
+``meta``
+  Argument to specify what meta information to return with the raw
+  message on the UMB.
+  Options are: ``title``, ``subtitle``, ``icon``, ``secondary_icon``, ``link``,
+  ``usernames``, ``packages``, ``objects``, and ``date``.
+
+  Default: None
+
+``grouped``
+  Argument to specify if the server should attempt to group together similar
+  messages.  Must be one of either "true" or "false".
+
+  Default: false
+
+``chrome``
+  "chrome" decides whether the messages should be displayed with html boiler-plate
+  or not. Must be one of either "true" or "false". "true" means with boiler-plate and
+  "false" implies without it.
+
+  Default: true
+
+``size``
+  Argument need to be specified if you want to receive different kinds of message cards.
+  Options are: small, medium, large, and extra-large.
+  ``"small"`` contains link and title. ``"medium"`` contains link, title, icon
+  and subtitle.  ``"large"`` contains link, title, icon, subtitle,
+  secondary_icon and datetime.  ``"extra-large"`` contains those of "large",
+  but it also displays the full JSON body of the raw message.
+
+  Default: large
+
+/id
+---
+
+Returns the message by the particular message-id given by the user.
+
+Formatting arguments
+====================
+
+``chrome``
+  Same as that of /raw
+
+``size``
+  Same as that of /raw
+
+``is_raw``
+  Checks whether the card is coming from /raw url or not. Must be one of either "true" or "false".
+  If card is from /raw url then it will be "true" otherwise "false".

--- a/datagrepper-docs/widget.rst
+++ b/datagrepper-docs/widget.rst
@@ -1,0 +1,59 @@
+Embeddable Widget
+-----------------
+
+Datagrepper provides a self expanding javascript file that you can use to embed
+message history in your internal blog, website, or application.
+
+Usage
+-----
+
+You simply include a ``<script>`` tag with the id ``datagrepper-widget`` that
+references ``widget.js``.  You can indicate what you would like it to display
+by using HTML5 ``data-*`` attributes.  If you don't know what those are, don't
+sweat it.  An example is worth a thousand words::
+
+    <html>
+      <body>
+        <h1>My Site</h1>
+        <p class="lead">Welcome to my site.</p>
+        <p>Here is my latest internal activity:</p>
+
+        <script id="datagrepper-widget"
+          src="https://datagrepper.engineering.redhat.com/datagrepper/widget.js?css=true"
+          data-user="psabata"
+          data-rows_per_page="40">
+        </script>
+
+        <footer>Happy Hacking!</footer>
+      </body>
+    </html>
+
+
+See that script tag in the middle?  The ``src`` attribute points at the URL
+that you'll want to copy and paste.  It optionally takes a ``css`` argument on
+the end which tells it whether or not to include datagrepper's own css.  You
+might, for instance, want to style the datagrepper message using your site's
+*own* css, not datagrepper's theme.  To do this you can omit the ``css=True``
+argument and then define your own style, like so::
+
+    <style>
+        #datagrepper-widget img {
+            height: 32px;
+            width: 32px;
+        }
+        #datagrepper-widget .message-card {
+            font-style: bold;
+            display: inline;
+        }
+        #datagrepper-widget .datetime {
+            font-style: italic;
+        }
+    </style>
+
+
+Next comes two ``data-*`` attributes that should look familiar from the
+JSON api docs.  The first indicates that the widget should render only messages
+relating to the LDAP user "psabata".  The second indicates that it should
+display the latest 40 messages (or as many as it can find).  You can specify
+any of the normal attributes: ``data-user``, ``data-package``,
+``data-category``, etc.


### PR DESCRIPTION
These can be referenced by fedora-infra/datagrepper#193.

... I just don't know where else to put them for now.  Eventually, they
should go in an ansible repo or better a repo containing the Dockerfile
we use to define our container for openshift deployment.

For now, can they live here?