### PR TITLE
I don't think flake8 is actually required for setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ long_description = long_description.split('split here', 1)[1]
 f.close()
 
 setup_requires = [
-    'flake8',
 ]
 install_requires = [
     'fedmsg',


### PR DESCRIPTION
It is used in `tox.ini`... but that pulls it into the virtualenv at test
time.  Am I missing something?