### PR TITLE
Add initial MetaXOR metadata processors

### DIFF
--- a/fedmsg_meta_umb/metaxor.py
+++ b/fedmsg_meta_umb/metaxor.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# fedmsg_meta_umb is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg_meta_umb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Stanislav Ochotnicky <sochotnicky@redhat.com>
+
+from fedmsg.meta.base import BaseProcessor
+
+
+class MetaXORProcessor(BaseProcessor):
+    topic_prefix_re = r'/topic/VirtualTopic\.eng'
+
+    __name__ = 'metaxor'
+    __description__ = 'a service storing information about container images ' \
+                      'in Lightblue'
+    __link__ = 'https://docs.engineering.redhat.com/x/MxSPAg'
+    __docs__ = 'https://docs.engineering.redhat.com/x/MxSPAg'
+    __icon__ = ('https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
+                'umb/_static/img/icons/metaxor.png')
+    __obj__ = 'Metaxor'
+
+    def title(self, msg, **config):
+        return msg['topic'].split('.', 2)[-1]
+
+    def subtitle(self, msg, **config):
+        inner_msg = msg['msg']
+        topic = msg['topic']
+        publish = 'published' if inner_msg.get('published') else 'unpublished'
+
+        if topic.endswith('containerImage.update'):
+            template = self._('Existing containerImage entity for {publish} '
+                              'container image {brew_build} has been updated.')
+        elif topic.endswith('containerImage.insert'):
+            template = self._('New containerImage entity for {publish} '
+                              'container image {brew_build} has been created.')
+        elif topic.endswith('events.refresh'):
+            template = self._('Container repository {repository} has been '
+                              'refreshed in Lightblue.')
+        else:
+            template = 'Unknown message.'
+
+        return template.format(publish=publish, **inner_msg)
+
+    def link(self, msg, **config):
+        inner_msg = msg['msg']
+        topic = msg['topic']
+        if topic.endswith('events.refresh'):
+            template = ('https://access.redhat.com/containers/#/'
+                        'registry.access.redhat.com/{repository}')
+            return template.format(**inner_msg)
+        elif (topic.endswith('containerImage.update') or
+              topic.endswith('containerImage.insert')):
+            template = ('https://brewweb.engineering.redhat.com/brew/search?'
+                        'terms={brew_build}&type=build&match=exact')
+            return template.format(**inner_msg)
+        return None
+
+    def packages(self, msg, **config):
+        if msg['topic'].endswith('containerImage.update') or \
+           msg['topic'].endswith('containerImage.insert'):
+            return set([msg['msg']['brew_build'].rsplit('-', 2)[0]])
+        else:
+            return set([])

--- a/fedmsg_meta_umb/tests/test_metaxor.py
+++ b/fedmsg_meta_umb/tests/test_metaxor.py
@@ -1,0 +1,201 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# fedmsg_meta_umb is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg_meta_umb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Stanislav Ochotnicky <sochotnicky@redhat.com>
+
+import fedmsg.tests.test_meta
+from .common import add_doc
+
+class TestMetaXORcontainerImageInsert(fedmsg.tests.test_meta.Base):
+    """ The MetaXOR service provides images to lightblue database
+
+    Messages (like the example given here) are published when information about
+    new image gets stored in Lightblue
+    """
+    expected_title = 'metaxor.events.lightblue.containerImage.insert'
+    expected_subti = ('New containerImage entity for unpublished container image '
+                      'aos3-installation-docker-v3.3.1.46.37-1 has been created.')
+    expected_link = ('https://brewweb.engineering.redhat.com/brew/search?'
+                     'terms=aos3-installation-docker-v3.3.1.46.37-1&'
+                     'type=build&match=exact')
+    expected_packages = set(['aos3-installation-docker'])
+    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
+                     'redhat.com/umb/_static/img/icons/metaxor.png')
+
+    msg = {
+        "username": None,
+        "source_name": "datanommer",
+        "certificate": None,
+        "i": 0,
+        "timestamp": 1516924184.0,
+        "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com"
+        "-42569-1516420517578-2:230301:0:0:1",
+        "crypto": None,
+        "topic": "/topic/VirtualTopic.eng.metaxor.events.lightblue.containerImage.insert",
+        "headers": {
+            "content-length": "187",
+            "expires": "0",
+            "JMS_AMQP_MESSAGE_FORMAT": "0",
+            "overridden": "false",
+            "full_refresh": "false",
+            "force_refresh": "false",
+            "JMS_AMQP_NATIVE": "false",
+            "destination": "/topic/VirtualTopic.eng.metaxor.events.lightblue."
+            "containerImage.insert",
+            "schema_version": "1.0.4",
+            "priority": "4",
+            "subscription": "/queue/Consumer.client-datanommer.openpaas-prod."
+            "VirtualTopic.eng.>",
+            "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2."
+            "redhat.com-42569-1516420517578-2:230301:0:0:1",
+            "timestamp": "0",
+            "published": "false",
+            "JMS_AMQP_FirstAcquirer": "false",
+            "changes": "[]",
+            "brew_build": "aos3-installation-docker-v3.3.1.46.37-1"
+        },
+        "signature": None,
+        "source_version": "0.8.2",
+        "msg": {
+            "overridden": False,
+            "force_refresh": False,
+            "full_refresh": False,
+            "schema_version": "1.0.4",
+            "published": False,
+            "changes": [],
+            "brew_build": "aos3-installation-docker-v3.3.1.46.37-1"
+        }
+    }
+
+
+class TestMetaXORcontainerImageUpdate(fedmsg.tests.test_meta.Base):
+    """ The MetaXOR service provides images to lightblue database
+
+    Messages (like the example given here) are published when the existing image
+    in lightblue gets updated
+    """
+    expected_title = 'metaxor.events.lightblue.containerImage.update'
+    expected_subti = ('Existing containerImage entity for published container '
+                      'image etcd-docker-3.2.11-2 has been updated.')
+    expected_link = ('https://brewweb.engineering.redhat.com/brew/search?'
+                     'terms=etcd-docker-3.2.11-2&type=build&match=exact')
+    expected_packages = set(['etcd-docker'])
+    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
+                     'redhat.com/umb/_static/img/icons/metaxor.png')
+
+    msg = {
+        'username': None,
+        'source_name': 'datanommer',
+        'certificate': None,
+        'i': 0,
+        'timestamp': 1517059491.0,
+        'msg_id': 'ID:messaging-devops-broker02.web.prod.ext.phx2.redhat'
+        '.com-42569-1516420517578-2:283330:0:0:1',
+        'crypto': None,
+        'topic': '/topic/VirtualTopic.eng.metaxor.events.lightblue.'
+        'containerImage.update',
+        'headers': {
+            'content-length': '206',
+            'full_refresh': 'false',
+            'JMS_AMQP_MESSAGE_FORMAT': '0',
+            'overridden': 'false',
+            'force_refresh': 'true',
+            'JMS_AMQP_NATIVE': 'false',
+            'expires': '0',
+            'published': 'true',
+            'schema_version': '1.0.4',
+            'priority': '4',
+            'JMS_AMQP_FirstAcquirer': 'false',
+            'timestamp': '0',
+            'destination': '/topic/VirtualTopic.eng.metaxor.events.'
+            'lightblue.containerImage.update',
+            'message-id': 'ID:messaging-devops-broker02.web.prod.ext.'
+            'phx2.redhat.com-42569-1516420517578-2:283330:0:0:1',
+            'changes': '[brew, lastUpdateDate, repositories]',
+            'brew_build': 'etcd-docker-3.2.11-2',
+            'subscription': '/queue/Consumer.client-datanommer.'
+            'openpaas-prod.VirtualTopic.eng.>'
+        },
+        'signature': None,
+        'source_version': '0.8.2',
+        'msg': {
+            'overridden': False,
+            'force_refresh': True,
+            'full_refresh': False,
+            'schema_version': '1.0.4',
+            'published': True,
+            'changes': [
+                'brew',
+                'lastUpdateDate',
+                'repositories'
+            ],
+            'brew_build': 'etcd-docker-3.2.11-2'
+        }
+    }
+
+class TestMetaXORRefreshEvent(fedmsg.tests.test_meta.Base):
+    """ The MetaXOR service provides images to lightblue database
+
+    Messages (like the example given here) are published when MetaXOR finishes
+    refreshing metadata about whole repository
+    """
+    expected_title = 'metaxor.events.refresh'
+    expected_subti = ('Container repository openshift3/registry-console '
+                      'has been refreshed in Lightblue.')
+    expected_link = ('https://access.redhat.com/containers/#/'
+                     'registry.access.redhat.com/openshift3/registry-console')
+    expected_packages = set([])
+    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
+                     'redhat.com/umb/_static/img/icons/metaxor.png')
+
+    msg = {
+        "username": None,
+        "source_name": "datanommer",
+        "certificate": None,
+        "i": 0,
+        "timestamp": 1517069378.0,
+        "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2."
+        "redhat.com-42569-1516420517578-2:285156:0:0:1",
+        "crypto": None,
+        "topic": "/topic/VirtualTopic.eng.metaxor.events.refresh",
+        "headers": {
+            "repository_filter": "null",
+            "content-length": "95",
+            "destination": "/topic/VirtualTopic.eng.metaxor.events.refresh",
+            "JMS_AMQP_MESSAGE_FORMAT": "0",
+            "repository": "openshift3/registry-console",
+            "full_refresh": "false",
+            "JMS_AMQP_NATIVE": "false",
+            "expires": "0",
+            "priority": "4",
+            "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2"
+            ".redhat.com-42569-1516420517578-2:285156:0:0:1",
+            "timestamp": "0",
+            "JMS_AMQP_FirstAcquirer": "false",
+            "subscription": "/queue/Consumer.client-datanommer.openpaas-prod."
+            "VirtualTopic.eng.>"
+        },
+        "signature": None,
+        "source_version": "0.8.2",
+        "msg": {
+            "repository_filter": None,
+            "full_refresh": False,
+            "repository": "openshift3/registry-console"
+        }
+    }
+
+
+add_doc(locals())

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ entry_points = {
         'freshmaker=fedmsg_meta_umb.freshmaker:FreshmakerProcessor',
         'odcs=fedmsg_meta_umb.odcs:ODCSProcessor',
         'resultsdb=fedmsg_meta_umb.resultsdb:ResultsDBProcessor',
+        'metaxor=fedmsg_meta_umb.metaxor:MetaXORProcessor'
     ]
 }
 


### PR DESCRIPTION
At the moment MetaXOR produces 3 types of messages:
 * New containerImage getting inserted
 * containerImage getting updated
 * When MetaXOR finished refreshing whole repository

More message types will be coming in the future.