### PR TITLE
Drop some mis-leading text.

### DIFF
--- a/fedmsg_meta_umb/freshmaker.py
+++ b/fedmsg_meta_umb/freshmaker.py
@@ -45,10 +45,10 @@ class FreshmakerProcessor(BaseProcessor):
                                   'from original build {original_nvr} to new '
                                   'build {rebuilt_nvr}.')
             else:
-                template = self._('{type_name} build state is switched to {state_name} '
-                                  'due to "{state_reason}"')
+                template = self._('{type_name} build state is switched to {state_name}: '
+                                  '"{state_reason}"')
         elif topic.endswith('event.state.changed'):
-            template = self._('Event state is switched to {state_name} due to "{state_reason}"')
+            template = self._('Event state is switched to {state_name}: "{state_reason}"')
         else:
             template = 'Unknown message.'
 

--- a/fedmsg_meta_umb/tests/test_freshmaker.py
+++ b/fedmsg_meta_umb/tests/test_freshmaker.py
@@ -100,7 +100,7 @@ class TestBuildStateIsDone(fedmsg.tests.test_meta.Base):
 class TestBuildStateIsNotDone(fedmsg.tests.test_meta.Base):
 
     expected_title = 'freshmaker.build.state.changed'
-    expected_subti = ('IMAGE build state is switched to FAILED due to '
+    expected_subti = ('IMAGE build state is switched to FAILED: '
                       '"Cannot build artifact, because its dependency '
                       'cannot be built."')
     expected_link = 'http://freshmaker.localhost/api/1/builds/96'
@@ -152,7 +152,7 @@ class TestBuildStateIsNotDone(fedmsg.tests.test_meta.Base):
 class TestEventStateChanged(fedmsg.tests.test_meta.Base):
 
     expected_title = 'freshmaker.event.state.changed'
-    expected_subti = ('Event state is switched to COMPLETE due to "Generated '
+    expected_subti = ('Event state is switched to COMPLETE: "Generated '
                       'ErrataAdvisoryRPMsSignedEvent '
                       '(ID:messaging-devops-broker01.localhost-46295-'
                       '1510954431290-2:473881:0:0:1) '
@@ -232,7 +232,7 @@ class TestUnknownMessageComes(fedmsg.tests.test_meta.Base):
 
 class TestAllBuildsDone(fedmsg.tests.test_meta.Base):
     expected_title = 'freshmaker.event.state.changed'
-    expected_subti = ('Event state is switched to COMPLETE due to "All docker '
+    expected_subti = ('Event state is switched to COMPLETE: "All docker '
                       'images have been rebuilt."')
     expected_link = 'http://freshmaker.localhost/api/1/events/242'
     expected_icon = (


### PR DESCRIPTION
Here, we sometimes mislead the reader.  I saw a message today that read:

> Event state is switched to COMPLETE due to "17 container image(s) failed to rebuild."

Why is it complete if 17 failed?  When I looked more closely, I found that
there were 40 images.  23 of them succeeded and 17 failed.  The
`state_reason` is really more like a `summary`, so let's expose it that
way to users.  # Please enter the commit message for your changes. Lines
starting