### PR TITLE
Add handlers for Metaxor's container repo messages

### DIFF
--- a/fedmsg_meta_umb/metaxor.py
+++ b/fedmsg_meta_umb/metaxor.py
@@ -52,6 +52,12 @@ class MetaXORProcessor(BaseProcessor):
         elif topic.endswith('containerImage.insert'):
             template = self._('New containerImage entity for {publish} '
                               'container image {brew_build} has been created.')
+        elif topic.endswith('containerRepository.insert'):
+            template = self._('New {publish} container repository '
+                              '{repository} has been created.')
+        elif topic.endswith('containerRepository.update'):
+            template = self._('Existing {publish} container repository '
+                              '{repository} has been updated.')
         elif topic.endswith('events.refresh'):
             template = self._('Container repository {repository} has been '
                               'refreshed in Lightblue.')
@@ -63,7 +69,9 @@ class MetaXORProcessor(BaseProcessor):
     def link(self, msg, **config):
         inner_msg = msg['msg']
         topic = msg['topic']
-        if topic.endswith('events.refresh'):
+        if (topic.endswith('events.refresh') or
+                topic.endswith('containerRepository.insert') or
+                topic.endswith('containerRepository.update')):
             template = ('https://access.redhat.com/containers/#/'
                         'registry.access.redhat.com/{repository}')
             return template.format(**inner_msg)
@@ -80,3 +88,10 @@ class MetaXORProcessor(BaseProcessor):
             return set([msg['msg']['brew_build'].rsplit('-', 2)[0]])
         else:
             return set([])
+
+    def objects(self, msg, **config):
+        if msg['topic'].endswith('containerRepository.update') or \
+           msg['topic'].endswith('containerRepository.insert'):
+            return {msg['msg']['repository']}
+        else:
+            return set()

--- a/fedmsg_meta_umb/tests/test_metaxor.py
+++ b/fedmsg_meta_umb/tests/test_metaxor.py
@@ -254,7 +254,8 @@ class TestMetaXORBadMessage(fedmsg.tests.test_meta.Base):
     expected_title = 'metaxor.internal.refresh'
     expected_subti = ('Unknown message format')
     expected_link = None
-    expected_packages = set([])
+    expected_packages = set()
+    expected_objects = set()
     expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
                      'redhat.com/umb/_static/img/icons/metaxor.png')
 
@@ -288,6 +289,134 @@ class TestMetaXORBadMessage(fedmsg.tests.test_meta.Base):
         "signature": None,
         "source_version": "0.8.2",
         "msg": 123
+    }
+
+
+class TestMetaXORcontainerRepositoryInsert(fedmsg.tests.test_meta.Base):
+    """ The MetaXOR service provides repositories to lightblue database
+
+    Messages (like the example given here) are published when the new
+    repository is created in Lightblue
+    """
+    expected_title = 'metaxor.events.lightblue.containerRepository.insert'
+    expected_subti = ('New published container repository rhel7/rhel has '
+                      'been created.')
+    expected_link = ('https://access.redhat.com/containers/#/'
+                     'registry.access.redhat.com/rhel7/rhel')
+    expected_objects = {'rhel7/rhel'}
+    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
+                     'redhat.com/umb/_static/img/icons/metaxor.png')
+
+    msg = {
+        'username': None,
+        'source_name': 'datanommer',
+        'certificate': None,
+        'i': 0,
+        'timestamp': 1517059491.0,
+        'msg_id': 'ID:messaging-devops-broker02.web.prod.ext.phx2.redhat'
+        '.com-42569-1516420517578-2:283330:0:0:1',
+        'crypto': None,
+        'topic': '/topic/VirtualTopic.eng.metaxor.events.lightblue'
+                 '.containerRepository.insert',
+        'headers': {
+            'content-length': '206',
+            'full_refresh': 'false',
+            'JMS_AMQP_MESSAGE_FORMAT': '0',
+            'overridden': 'false',
+            'force_refresh': 'true',
+            'JMS_AMQP_NATIVE': 'false',
+            'expires': '0',
+            'published': 'true',
+            'schema_version': '1.0.0',
+            'priority': '4',
+            'JMS_AMQP_FirstAcquirer': 'false',
+            'timestamp': '0',
+            'destination': '/topic/VirtualTopic.eng.metaxor.events.'
+            'lightblue.containerRepository.insert',
+            'message-id': 'ID:messaging-devops-broker02.web.prod.ext.'
+            'phx2.redhat.com-42569-1516420517578-2:283330:0:0:1',
+            'changes': '[lastUpdateDate]',
+            'brew_build': 'etcd-docker-3.2.11-2',
+            'subscription': '/queue/Consumer.client-datanommer.'
+            'openpaas-prod.VirtualTopic.eng.>'
+        },
+        'signature': None,
+        'source_version': '0.8.2',
+        'msg': {
+            'published': True,
+            'repository': 'rhel7/rhel',
+            'registry': 'registry.access.redhat.com',
+            'full_refresh': False,
+            'force_refresh': False,
+            'schema_version': '1.0.0',
+            'changes': [
+                'lastUpdateDate'
+            ]
+        }
+    }
+
+
+class TestMetaXORcontainerRepositoryUpdate(fedmsg.tests.test_meta.Base):
+    """ The MetaXOR service provides repositories to lightblue database
+
+    Messages (like the example given here) are published when the existing
+    repository is updated in Lightblue
+    """
+    expected_title = 'metaxor.events.lightblue.containerRepository.update'
+    expected_subti = ('Existing published container repository rhel7/rhel has '
+                      'been updated.')
+    expected_link = ('https://access.redhat.com/containers/#/'
+                     'registry.access.redhat.com/rhel7/rhel')
+    expected_objects = {'rhel7/rhel'}
+    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
+                     'redhat.com/umb/_static/img/icons/metaxor.png')
+
+    msg = {
+        'username': None,
+        'source_name': 'datanommer',
+        'certificate': None,
+        'i': 0,
+        'timestamp': 1517059491.0,
+        'msg_id': 'ID:messaging-devops-broker02.web.prod.ext.phx2.redhat'
+        '.com-42569-1516420517578-2:283330:0:0:1',
+        'crypto': None,
+        'topic': '/topic/VirtualTopic.eng.metaxor.events.lightblue'
+                 '.containerRepository.update',
+        'headers': {
+            'content-length': '206',
+            'full_refresh': 'false',
+            'JMS_AMQP_MESSAGE_FORMAT': '0',
+            'overridden': 'false',
+            'force_refresh': 'true',
+            'JMS_AMQP_NATIVE': 'false',
+            'expires': '0',
+            'published': 'true',
+            'schema_version': '1.0.0',
+            'priority': '4',
+            'JMS_AMQP_FirstAcquirer': 'false',
+            'timestamp': '0',
+            'destination': '/topic/VirtualTopic.eng.metaxor.events.'
+            'lightblue.containerRepository.update',
+            'message-id': 'ID:messaging-devops-broker02.web.prod.ext.'
+            'phx2.redhat.com-42569-1516420517578-2:283330:0:0:1',
+            'changes': '[lastUpdateDate]',
+            'brew_build': 'etcd-docker-3.2.11-2',
+            'subscription': '/queue/Consumer.client-datanommer.'
+            'openpaas-prod.VirtualTopic.eng.>'
+        },
+        'signature': None,
+        'source_version': '0.8.2',
+        'msg': {
+            'published': True,
+            'repository': 'rhel7/rhel',
+            'registry': 'registry.access.redhat.com',
+            'full_refresh': False,
+            'force_refresh': False,
+            'schema_version': '1.0.0',
+            'changes': [
+                'lastUpdateDate'
+            ]
+        }
     }
 
 


### PR DESCRIPTION
MX started producing messages when new or existing repository is created
or updated in database.

The messages are sent to following topics:
 - metaxor.events.lightblue.containerRepository.insert
 - metaxor.events.lightblue.containerRepository.update