### PR TITLE
greenwave: add support for brew-build type

### DIFF
--- a/fedmsg_meta_umb/greenwave.py
+++ b/fedmsg_meta_umb/greenwave.py
@@ -68,6 +68,6 @@ class GreenwaveProcessor(BaseProcessor):
         subject = msg['msg']['subject']
         items = [
             entry.get('item') for entry in subject
-            if entry.get('item') and entry.get('type') == 'koji_build'
+            if entry.get('item') and entry.get('type') in ['brew-build', 'koji_build']
         ]
         return set([item.rsplit('-', 2)[0] for item in items])

--- a/fedmsg_meta_umb/tests/test_greenwave.py
+++ b/fedmsg_meta_umb/tests/test_greenwave.py
@@ -21,13 +21,15 @@ import fedmsg.tests.test_meta
 from .common import add_doc
 
 
-class TestGreenwaveDecisionUpdate(fedmsg.tests.test_meta.Base):
+class TestGreenwaveDecisionUpdateErrataNewFiles(fedmsg.tests.test_meta.Base):
     """ Greenwave is a service to decide whether a software artifact can
     pass certain gating points in a software delivery pipeline, based on test
     results stored in ResultsDB and waivers stored in WaiverDB.
 
     Greenwave publishes a message when a new result/waiver causes the
     decision to change.
+
+    This decision is for Erratum moving to New Files state.
     """
     expected_title = 'greenwave.decision.update'
     expected_subti = ('greenwave is a GO on libXdmcp-1.1.2-9.el8 for '
@@ -91,6 +93,96 @@ class TestGreenwaveDecisionUpdate(fedmsg.tests.test_meta.Base):
                     "1"
                 ]
             }
+        }
+    }
+
+
+class TestGreenwaveDecisionUpdateComposeGate(fedmsg.tests.test_meta.Base):
+    """ Greenwave is a service to decide whether a software artifact can
+    pass certain gating points in a software delivery pipeline, based on test
+    results stored in ResultsDB and waivers stored in WaiverDB.
+
+    Greenwave publishes a message when a new result/waiver causes the
+    decision to change.
+
+    This decision is for compose gating.
+    """
+    expected_title = 'greenwave.decision.update'
+    expected_subti = ('greenwave says NO-GO on libsemanage-2.8-2.el8+7 for '
+                      '"osci_compose_gate" (rhel-8)')
+    expected_link = ('https://resultsdb.engineering.redhat.com/'
+                     'results?item=libsemanage-2.8-2.el8%2B7&type=brew-build')
+    expected_packages = set(['libsemanage'])
+    expected_icon = (
+        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
+        'umb/_static/img/icons/greenwave.png')
+
+    msg = {
+        "username": "upshift",
+        "source_name": "datanommer",
+        "certificate": None,
+        "i": 39446,
+        "timestamp": 1528403467.0,
+        "msg_id": "2018-3337fe81-2e0b-4048-a963-068b34405205",
+        "crypto": None,
+        "topic": "/topic/VirtualTopic.eng.greenwave.decision.update",
+        "headers": {
+            "expires": "1529008267689",
+            "timestamp": "1528403467689",
+            "destination": "/topic/VirtualTopic.eng.greenwave.decision.update",
+            "priority": "4",
+            "message-id": "ID:messaging-devops-broker01.web.prod.ext.phx2.redhat.com"
+                          "-42045-1527890187852-2:112143:-1:1:1",
+            "content-type": "text/plain",
+            "subscription": "/queue/Consumer.client-datanommer.openpaas-prod.VirtualTopic.eng.>"
+        },
+        "signature": None,
+        "source_version": "0.9.0",
+        "msg": {
+            "policies_satisfied": False,
+            "decision_context": "osci_compose_gate",
+            "product_version": "rhel-8",
+            "applicable_policies": [
+                "osci_compose"
+            ],
+            "unsatisfied_requirements": [
+                {
+                    "testcase": "osci.brew-build.tier0.functional",
+                    "item": {
+                        "item": "libsemanage-2.8-2.el8+7",
+                        "type": "brew-build"
+                    },
+                    "result_id": 5036102,
+                    "scenario": None,
+                    "type": "test-result-failed"
+                }
+            ],
+            "previous": {
+                "summary": "1 of 1 required tests failed",
+                "policies_satisfied": False,
+                "unsatisfied_requirements": [
+                    {
+                        "testcase": "osci.brew-build.tier0.functional",
+                        "item": {
+                            "item": "libsemanage-2.8-2.el8+7",
+                            "type": "brew-build"
+                        },
+                        "result_id": 5016237,
+                        "scenario": None,
+                        "type": "test-result-failed"
+                    }
+                ],
+                "applicable_policies": [
+                    "osci_compose"
+                ]
+            },
+            "summary": "1 of 1 required tests failed",
+            "subject": [
+                {
+                    "item": "libsemanage-2.8-2.el8+7",
+                    "type": "brew-build"
+                }
+            ]
         }
     }
 


### PR DESCRIPTION
The decision updates for compose gate have different item type.
Make sure to support it in packages mapping.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>