### PR TITLE
Add usernames

### DIFF
--- a/fedmsg_meta_umb/jira.py
+++ b/fedmsg_meta_umb/jira.py
@@ -47,19 +47,15 @@ class JIRAProcessor(BaseProcessor):
         if topic.endswith('jira.issue.created'):
             template = self._('New JIRA issue {key} has been created.')
         elif topic.endswith('jira.issue.updated'):
-            # default to generic update message
             template = self._('JIRA issue {key} has been updated.')
-            if inner_msg['comment']['author']:
-                # there was a new/updated comment (non-empty author dict)
-                data['author'] = inner_msg['comment']['author']['displayName']
-                data['created'] = inner_msg['comment']['created']
-                data['updated'] = inner_msg['comment']['updated']
-                if data['created'] == data['updated']:
-                    template = self._("{author} added new comment in JIRA "
-                                      "issue {key}.")
-                else:
-                    template = self._("{author} updated comment in JIRA "
-                                      "issue {key}.")
+        elif topic.endswith("jira.comment.added"):
+            data['author'] = inner_msg['comment']['author']['displayName']
+            template = self._("{author} added new comment in JIRA issue "
+                              "{key}.")
+        elif topic.endswith("jira.comment.updated"):
+            data['author'] = inner_msg['comment']['author']['displayName']
+            template = self._("{author} updated comment in JIRA issue "
+                              "{key}.")
         else:
             template = 'Unknown message.'
 
@@ -69,15 +65,13 @@ class JIRAProcessor(BaseProcessor):
         inner_msg = msg['msg']
         topic = msg['topic']
         comment_id = None
-        if (topic.endswith('jira.issue.created') or
-                topic.endswith('jira.issue.updated')):
-            template = self.__link__ + "/browse/{key}"
-            if inner_msg['comment']['author']:
-                comment_id = inner_msg['comment']['id']
-                template = template + "?focusedCommentId={comment_id}"
-            try:
-                return template.format(key=inner_msg['issue']['key'],
-                                       comment_id=comment_id)
-            except KeyError:
-                return None
-        return None
+        template = self.__link__ + "/browse/{key}"
+        if (topic.endswith('jira.comment.added') or
+                topic.endswith('jira.comment.updated')):
+            comment_id = inner_msg['comment']['id']
+            template = template + "?focusedCommentId={comment_id}"
+        try:
+            return template.format(key=inner_msg['issue']['key'],
+                                   comment_id=comment_id)
+        except KeyError:
+            return None

--- a/fedmsg_meta_umb/jira.py
+++ b/fedmsg_meta_umb/jira.py
@@ -39,23 +39,30 @@ class JIRAProcessor(BaseProcessor):
             # these will only be available on issue create/update but not
             # comment added/edited messages
             data['key'] = inner_msg['issue']['key']
+            data['issue_type'] = inner_msg['issue']['fields']['issuetype']['name']
             data['summary'] = inner_msg['issue']['fields']['summary']
         except KeyError:
             return None
         topic = msg['topic']
 
         if topic.endswith('jira.issue.created'):
-            template = self._('New JIRA issue {key} has been created.')
+            data['author'] = inner_msg['user']['displayName']
+            template = self._('{issue_type} {key} has been created by '
+                              '{author}.')
         elif topic.endswith('jira.issue.updated'):
-            template = self._('JIRA issue {key} has been updated.')
+            data['author'] = inner_msg['user']['displayName']
+            template = self._('{issue_type} {key} has been updated by '
+                              '{author}.')
         elif topic.endswith("jira.comment.added"):
             data['author'] = inner_msg['comment']['author']['displayName']
-            template = self._("{author} added new comment in JIRA issue "
-                              "{key}.")
+            data['issue_type'] = data['issue_type'].lower()
+            template = self._('Comment has been added by {author} in {issue_type} '
+                              '{key}.')
         elif topic.endswith("jira.comment.updated"):
-            data['author'] = inner_msg['comment']['author']['displayName']
-            template = self._("{author} updated comment in JIRA issue "
-                              "{key}.")
+            data['author'] = inner_msg['comment']['updateAuthor']['displayName']
+            data['issue_type'] = data['issue_type'].lower()
+            template = self._('Comment has been edited by {author} in {issue_type} '
+                              '{key}.')
         else:
             template = 'Unknown message.'
 

--- a/fedmsg_meta_umb/jira.py
+++ b/fedmsg_meta_umb/jira.py
@@ -114,3 +114,9 @@ class JIRAProcessor(BaseProcessor):
         except KeyError:
             pass
         return names
+
+    def agent(self, msg, **config):
+        try:
+            return msg['msg']['user']['name']
+        except KeyError:
+            return None

--- a/fedmsg_meta_umb/jira.py
+++ b/fedmsg_meta_umb/jira.py
@@ -75,3 +75,35 @@ class JIRAProcessor(BaseProcessor):
                                    comment_id=comment_id)
         except KeyError:
             return None
+
+    def usernames(self, msg, **config):
+        names = set()
+        inner_msg = msg['msg']
+
+        # this is relatively readable at least. Various pieces can exist in
+        # different situations so let's just handle by ignoring missing places
+        try:
+            names.add(inner_msg['issue']['fields']['creator']['name'])
+        except KeyError:
+            pass
+        try:
+            names.add(inner_msg['issue']['fields']['assignee']['name'])
+        except KeyError:
+            pass
+        try:
+            names.add(inner_msg['issue']['fields']['reporter']['name'])
+        except KeyError:
+            pass
+        try:
+            names.add(inner_msg['comment']['author']['name'])
+        except KeyError:
+            pass
+        try:
+            names.add(inner_msg['comment']['updateAuthor']['name'])
+        except KeyError:
+            pass
+        try:
+            names.add(inner_msg['user']['name'])
+        except KeyError:
+            pass
+        return names

--- a/fedmsg_meta_umb/tests/test_jira.py
+++ b/fedmsg_meta_umb/tests/test_jira.py
@@ -31,6 +31,7 @@ class TestJIRAIssueCreate(fedmsg.tests.test_meta.Base):
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
     expected_usernames = set(['rbean', 'kboran'])
+    expected_agent = 'rbean'
 
     msg = {
         "username": None,
@@ -139,6 +140,7 @@ class TestJIRAIssueGenericUpdate(fedmsg.tests.test_meta.Base):
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
     expected_usernames = set(['rbean', 'red-user'])
+    expected_agent = 'red-user'
 
     msg = {
         "username": None,
@@ -252,6 +254,7 @@ class TestJIRAIssueAddComment(fedmsg.tests.test_meta.Base):
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
     expected_usernames = set(['brainfor', 'rbean', 'red-user'])
+    expected_agent = 'red-user'
 
     msg = {
         "username": None,
@@ -397,6 +400,7 @@ class TestJIRAIssueEditComment(fedmsg.tests.test_meta.Base):
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
     expected_usernames = set(['brainfor', 'rbean', 'red-user'])
+    expected_agent = 'red-user'
 
     msg = {
         "username": None,
@@ -541,6 +545,7 @@ class TestJIRAIssueMissingKey(fedmsg.tests.test_meta.Base):
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
     expected_usernames = set(['brainfor', 'rbean', 'red-user'])
+    expected_agent = 'red-user'
 
     msg = {
         "username": None,

--- a/fedmsg_meta_umb/tests/test_jira.py
+++ b/fedmsg_meta_umb/tests/test_jira.py
@@ -25,7 +25,7 @@ class TestJIRAIssueCreate(fedmsg.tests.test_meta.Base):
     created
     """
     expected_title = 'jira.issue.created'
-    expected_subti = 'New JIRA issue DEVOPSA-4091 has been created.'
+    expected_subti = 'Task DEVOPSA-4091 has been created by Ralph Bean.'
     expected_link = ('https://projects.engineering.redhat.com/browse/'
                      'DEVOPSA-4091')
     expected_packages = set([])
@@ -77,14 +77,6 @@ class TestJIRAIssueCreate(fedmsg.tests.test_meta.Base):
                     },
                     "updated": "2018-08-20T16:40:09.644+0000",
                     "description": "Proper long description",
-                    "creator": {
-                        "displayName": "Ralph Bean",
-                        "name": "rbean",
-                        "emailAddress": "rbean@redhat.com",
-                        "key": "rbean",
-                        "active": True,
-                        "timeZone": "America/Havana"
-                    },
                     "created": "2018-08-20T16:40:09.644+0000",
                     "votes": {},
                     "watches": {},
@@ -141,7 +133,7 @@ class TestJIRAIssueGenericUpdate(fedmsg.tests.test_meta.Base):
     added/removed as well
     """
     expected_title = 'jira.issue.updated'
-    expected_subti = 'JIRA issue FACTORY-2904 has been updated.'
+    expected_subti = 'Bug FACTORY-2904 has been updated by red-user.'
     expected_link = ('https://projects.engineering.redhat.com/browse/'
                      'FACTORY-2904')
     expected_packages = set([])
@@ -217,27 +209,11 @@ class TestJIRAIssueGenericUpdate(fedmsg.tests.test_meta.Base):
                         "name": "Factory 2.0",
                         "key": "FACTORY"
                     },
-                    "assignee": {
-                        "displayName": "Ralph Bean",
-                        "name": "rbean",
-                        "emailAddress": "rbean@redhat.com",
-                        "key": "rbean",
-                        "active": True,
-                        "timeZone": "America/Havana"
-                    },
                     "issuetype": {
                         "description": "A problem which impairs functions.",
                         "name": "Bug"
                     },
                     "resolution": {},
-                    "reporter": {
-                        "displayName": "Ralph Bean",
-                        "name": "rbean",
-                        "emailAddress": "rbean@redhat.com",
-                        "key": "rbean",
-                        "active": True,
-                        "timeZone": "America/Havana"
-                    }
                 },
                 "key": "FACTORY-2904"
             },
@@ -270,7 +246,7 @@ class TestJIRAIssueAddComment(fedmsg.tests.test_meta.Base):
     updated by posting a new comment.
     """
     expected_title = 'jira.comment.added'
-    expected_subti = 'Bill Rainford added new comment in JIRA issue FACTORY-2904.'
+    expected_subti = 'Comment has been added by Bill Rainford in bug FACTORY-2904.'
     expected_link = ('https://projects.engineering.redhat.com/browse/'
                      'FACTORY-2904?focusedCommentId=973188')
     expected_packages = set([])
@@ -415,7 +391,7 @@ class TestJIRAIssueEditComment(fedmsg.tests.test_meta.Base):
     updated by posting a new comment.
     """
     expected_title = 'jira.comment.updated'
-    expected_subti = 'Bill Rainford updated comment in JIRA issue FACTORY-2904.'
+    expected_subti = 'Comment has been edited by Bill Rainford in bug FACTORY-2904.'
     expected_link = ('https://projects.engineering.redhat.com/browse/'
                      'FACTORY-2904?focusedCommentId=973188')
     expected_packages = set([])

--- a/fedmsg_meta_umb/tests/test_jira.py
+++ b/fedmsg_meta_umb/tests/test_jira.py
@@ -30,6 +30,7 @@ class TestJIRAIssueCreate(fedmsg.tests.test_meta.Base):
                      'DEVOPSA-4091')
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
+    expected_usernames = set(['rbean', 'kboran'])
 
     msg = {
         "username": None,
@@ -145,6 +146,7 @@ class TestJIRAIssueGenericUpdate(fedmsg.tests.test_meta.Base):
                      'FACTORY-2904')
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
+    expected_usernames = set(['rbean', 'red-user'])
 
     msg = {
         "username": None,
@@ -273,6 +275,7 @@ class TestJIRAIssueAddComment(fedmsg.tests.test_meta.Base):
                      'FACTORY-2904?focusedCommentId=973188')
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
+    expected_usernames = set(['brainfor', 'rbean', 'red-user'])
 
     msg = {
         "username": None,
@@ -417,6 +420,7 @@ class TestJIRAIssueEditComment(fedmsg.tests.test_meta.Base):
                      'FACTORY-2904?focusedCommentId=973188')
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
+    expected_usernames = set(['brainfor', 'rbean', 'red-user'])
 
     msg = {
         "username": None,
@@ -560,6 +564,7 @@ class TestJIRAIssueMissingKey(fedmsg.tests.test_meta.Base):
     expected_link = None
     expected_packages = set([])
     expected_icon = 'https://projects.engineering.redhat.com/favicon.ico'
+    expected_usernames = set(['brainfor', 'rbean', 'red-user'])
 
     msg = {
         "username": None,

--- a/fedmsg_meta_umb/tests/test_jira.py
+++ b/fedmsg_meta_umb/tests/test_jira.py
@@ -267,7 +267,7 @@ class TestJIRAIssueAddComment(fedmsg.tests.test_meta.Base):
     Messages (like the example given here) are published when issue is
     updated by posting a new comment.
     """
-    expected_title = 'jira.issue.updated'
+    expected_title = 'jira.comment.added'
     expected_subti = 'Bill Rainford added new comment in JIRA issue FACTORY-2904.'
     expected_link = ('https://projects.engineering.redhat.com/browse/'
                      'FACTORY-2904?focusedCommentId=973188')
@@ -284,14 +284,14 @@ class TestJIRAIssueAddComment(fedmsg.tests.test_meta.Base):
         "ID:messaging-devops-broker01.web.prod.ext.phx2."
         "redhat.com-37550-1534679656045-2:40012:-1:1:132",
         "crypto": None,
-        "topic": "/topic/VirtualTopic.eng.jira.issue.updated",
+        "topic": "/topic/VirtualTopic.eng.jira.comment.added",
         "headers": {
             "priority": "4",
             "expires": "1535382740838",
             "event_type": "jira:issue_updated",
             "project": "FACTORY",
             "timestamp": "1534777940838",
-            "destination": "/topic/VirtualTopic.eng.jira.issue.updated",
+            "destination": "/topic/VirtualTopic.eng.jira.comment.added",
             "issue_key": "FACTORY-2904",
             "message-id":
             "ID:messaging-devops-broker01.web.prod.ext.phx2."
@@ -411,7 +411,7 @@ class TestJIRAIssueEditComment(fedmsg.tests.test_meta.Base):
     Messages (like the example given here) are published when issue is
     updated by posting a new comment.
     """
-    expected_title = 'jira.issue.updated'
+    expected_title = 'jira.comment.updated'
     expected_subti = 'Bill Rainford updated comment in JIRA issue FACTORY-2904.'
     expected_link = ('https://projects.engineering.redhat.com/browse/'
                      'FACTORY-2904?focusedCommentId=973188')
@@ -428,14 +428,14 @@ class TestJIRAIssueEditComment(fedmsg.tests.test_meta.Base):
         "ID:messaging-devops-broker01.web.prod.ext.phx2."
         "redhat.com-37550-1534679656045-2:40012:-1:1:132",
         "crypto": None,
-        "topic": "/topic/VirtualTopic.eng.jira.issue.updated",
+        "topic": "/topic/VirtualTopic.eng.jira.comment.updated",
         "headers": {
             "priority": "4",
             "expires": "1535382740838",
             "event_type": "jira:issue_updated",
             "project": "FACTORY",
             "timestamp": "1534777940838",
-            "destination": "/topic/VirtualTopic.eng.jira.issue.updated",
+            "destination": "/topic/VirtualTopic.eng.jira.comment.updated",
             "issue_key": "FACTORY-2904",
             "message-id":
             "ID:messaging-devops-broker01.web.prod.ext.phx2."


### PR DESCRIPTION
This makes two changes - adds usernames and also tweaks for new topics (comment added/removed). 

Comment addition now actually triggers two identical messages in different topics. This is because single update can make other changes besides the comment change