### PR TITLE
replace links to the old datagrepper instance

### DIFF
--- a/fedmsg_meta_umb/doc_utilities.py
+++ b/fedmsg_meta_umb/doc_utilities.py
@@ -91,7 +91,7 @@ def write(fname, s=''):
 def datagrepper_link(topic):
     suffix = topic.split('.', 1)[-1]
     category = topic.split('.')[2]
-    base_url = 'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/raw'
+    base_url = 'https://datagrepper.engineering.redhat.com/raw'
     topic_link = base_url + '?topic=%s' % topic
     category_link = base_url + '?category=%s' % category
     tmpl = (

--- a/fedmsg_meta_umb/freshmaker.py
+++ b/fedmsg_meta_umb/freshmaker.py
@@ -26,8 +26,7 @@ class FreshmakerProcessor(BaseProcessor):
     __description__ = 'a service scheduling rebuilds of artifacts as new content becomes available'
     __link__ = 'https://freshmaker.engineering.redhat.com'
     __docs__ = 'https://mojo.redhat.com/docs/DOC-1155261'
-    __icon__ = ('https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-                'umb/_static/img/icons/freshmaker.png')
+    __icon__ = '/umb/_static/img/icons/freshmaker.png'
     __obj__ = 'Artifact rebuild scheduler'
 
     def title(self, msg, **config):

--- a/fedmsg_meta_umb/greenwave.py
+++ b/fedmsg_meta_umb/greenwave.py
@@ -27,8 +27,7 @@ class GreenwaveProcessor(BaseProcessor):
     __link__ = 'https://greenwave.engineering.redhat.com/api/v1.0/policies'
     __obj__ = 'Gating Decisions'
     __docs__ = 'https://mojo.redhat.com/docs/DOC-1171796'
-    __icon__ = ('https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-                'umb/_static/img/icons/greenwave.png')
+    __icon__ = '/umb/_static/img/icons/greenwave.png'
 
     @staticmethod
     def satisfied(msg):

--- a/fedmsg_meta_umb/mbs.py
+++ b/fedmsg_meta_umb/mbs.py
@@ -27,9 +27,7 @@ class MBSProcessor(BaseProcessor):
     __link__ = 'https://mbs.engineering.redhat.com'
     __docs__ = 'https://gitlab.cee.redhat.com/rhel-appstream/module-maintainer-guide'
     __obj__ = 'Module Builds'
-    __icon__ = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/mbs.png')
+    __icon__ = '/umb/_static/img/icons/mbs.png'
 
     def title(self, msg, **config):
         return msg['topic'].split('.', 2)[-1]

--- a/fedmsg_meta_umb/metaxor.py
+++ b/fedmsg_meta_umb/metaxor.py
@@ -27,8 +27,7 @@ class MetaXORProcessor(BaseProcessor):
                       'in Lightblue'
     __link__ = 'https://docs.engineering.redhat.com/x/MxSPAg'
     __docs__ = 'https://docs.engineering.redhat.com/x/MxSPAg'
-    __icon__ = ('https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-                'umb/_static/img/icons/metaxor.png')
+    __icon__ = '/umb/_static/img/icons/metaxor.png'
     __obj__ = 'Metaxor'
 
     def title(self, msg, **config):

--- a/fedmsg_meta_umb/odcs.py
+++ b/fedmsg_meta_umb/odcs.py
@@ -26,9 +26,7 @@ class ODCSProcessor(BaseProcessor):
     __description__ = 'the On-Demand Compose Service'
     __link__ = 'https://odcs.engineering.redhat.com'
     __docs__ = 'https://pagure.io/odcs'
-    __icon__ = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/odcs.png')
+    __icon__ = '/umb/_static/img/icons/odcs.png'
     __obj__ = 'ODCS composes'
 
     def title(self, msg, **config):

--- a/fedmsg_meta_umb/resultsdb.py
+++ b/fedmsg_meta_umb/resultsdb.py
@@ -27,8 +27,7 @@ class ResultsDBProcessor(BaseProcessor):
     __link__ = 'https://resultsdb.engineering.redhat.com'
     __docs__ = 'https://mojo.redhat.com/docs/DOC-1131637'
     __obj__ = 'Results'
-    __icon__ = ('https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-                'umb/_static/img/icons/resultsdb.png')
+    __icon__ = '/umb/_static/img/icons/resultsdb.png'
 
     def title(self, msg, **config):
         return msg['topic'].split('.', 2)[-1]

--- a/fedmsg_meta_umb/tests/test_freshmaker.py
+++ b/fedmsg_meta_umb/tests/test_freshmaker.py
@@ -24,9 +24,7 @@ class TestManualRebuild(fedmsg.tests.test_meta.Base):
     expected_title = 'freshmaker.manual.rebuild'
     expected_subti = 'Manual rebuild is triggered for Errata advisory 31360.'
     expected_link = 'https://pipeline.engineering.redhat.com/advisory/31360'
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/freshmaker.png')
+    expected_icon = '/umb/_static/img/icons/freshmaker.png'
     expected_packages = set([])
 
     msg = {
@@ -53,9 +51,7 @@ class TestBuildStateIsDone(fedmsg.tests.test_meta.Base):
                       'from original build rh-nodejs6-docker-6-14.11 to new '
                       'build rh-nodejs6-docker-6-14.1511360844.')
     expected_link = 'https://pipeline.engineering.redhat.com/freshmakerevent/58'
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/freshmaker.png')
+    expected_icon = '/umb/_static/img/icons/freshmaker.png'
     expected_packages = set([])
 
     msg = {
@@ -104,9 +100,7 @@ class TestBuildStateIsNotDone(fedmsg.tests.test_meta.Base):
                       '"Cannot build artifact, because its dependency '
                       'cannot be built."')
     expected_link = 'https://pipeline.engineering.redhat.com/freshmakerevent/60'
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/freshmaker.png')
+    expected_icon = '/umb/_static/img/icons/freshmaker.png'
     expected_packages = set([])
 
     msg = {
@@ -158,9 +152,7 @@ class TestEventStateChanged(fedmsg.tests.test_meta.Base):
                       '1510954431290-2:473881:0:0:1) '
                       'for errata: RHSA-2017:29110"')
     expected_link = 'https://pipeline.engineering.redhat.com/freshmakerevent/81'
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/freshmaker.png')
+    expected_icon = '/umb/_static/img/icons/freshmaker.png'
     expected_packages = set(['pkg', 'another-pkg'])
 
     msg = {
@@ -198,9 +190,7 @@ class TestUnknownMessageComes(fedmsg.tests.test_meta.Base):
     expected_title = 'freshmaker.some.new.event'
     expected_subti = 'Unknown message.'
     expected_link = None
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/freshmaker.png')
+    expected_icon = '/umb/_static/img/icons/freshmaker.png'
     expected_packages = set([])
 
     msg = {
@@ -235,9 +225,7 @@ class TestAllBuildsDone(fedmsg.tests.test_meta.Base):
     expected_subti = ('Event state is switched to COMPLETE: "All docker '
                       'images have been rebuilt."')
     expected_link = 'https://pipeline.engineering.redhat.com/freshmakerevent/242'
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/freshmaker.png')
+    expected_icon = '/umb/_static/img/icons/freshmaker.png'
     expected_packages = set(['someimage', 'someimage2'])
     msg = {
         "headers": {

--- a/fedmsg_meta_umb/tests/test_greenwave.py
+++ b/fedmsg_meta_umb/tests/test_greenwave.py
@@ -37,9 +37,7 @@ class TestGreenwaveDecisionUpdateErrataNewFiles(fedmsg.tests.test_meta.Base):
                       '"errata_newfile_to_qe" (rhel-7)')
     expected_link = 'https://pipeline.engineering.redhat.com/kojibuild/libXdmcp-1.1.2-9.el8'
     expected_packages = set(['libXdmcp'])
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/greenwave.png')
+    expected_icon = '/umb/_static/img/icons/greenwave.png'
 
     msg = {
         "i": 0,
@@ -113,9 +111,7 @@ class TestGreenwaveDecisionUpdateComposeGate(fedmsg.tests.test_meta.Base):
                       '"osci_compose_gate" (rhel-8)')
     expected_link = 'https://pipeline.engineering.redhat.com/kojibuild/libsemanage-2.8-2.el8+7'
     expected_packages = set(['libsemanage'])
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/greenwave.png')
+    expected_icon = '/umb/_static/img/icons/greenwave.png'
 
     msg = {
         "username": "upshift",

--- a/fedmsg_meta_umb/tests/test_mbs.py
+++ b/fedmsg_meta_umb/tests/test_mbs.py
@@ -34,9 +34,7 @@ class TestMBSStateChange(fedmsg.tests.test_meta.Base):
     expected_agent = 'tdawson'
     expected_usernames = set(['tdawson'])
     expected_packages = set(['foobar'])
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/mbs.png')
+    expected_icon = '/umb/_static/img/icons/mbs.png'
 
     msg = {
         "username": None,

--- a/fedmsg_meta_umb/tests/test_metaxor.py
+++ b/fedmsg_meta_umb/tests/test_metaxor.py
@@ -32,8 +32,7 @@ class TestMetaXORcontainerImageInsert(fedmsg.tests.test_meta.Base):
                      'terms=aos3-installation-docker-v3.3.1.46.37-1&'
                      'type=build&match=exact')
     expected_packages = set(['aos3-installation-docker'])
-    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
-                     'redhat.com/umb/_static/img/icons/metaxor.png')
+    expected_icon = '/umb/_static/img/icons/metaxor.png'
 
     msg = {
         "username": None,
@@ -93,8 +92,7 @@ class TestMetaXORcontainerImageUpdate(fedmsg.tests.test_meta.Base):
     expected_link = ('https://brewweb.engineering.redhat.com/brew/search?'
                      'terms=etcd-docker-3.2.11-2&type=build&match=exact')
     expected_packages = set(['etcd-docker'])
-    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
-                     'redhat.com/umb/_static/img/icons/metaxor.png')
+    expected_icon = '/umb/_static/img/icons/metaxor.png'
 
     msg = {
         'username': None,
@@ -158,8 +156,7 @@ class TestMetaXORRefreshEvent(fedmsg.tests.test_meta.Base):
     expected_link = ('https://access.redhat.com/containers/#/'
                      'registry.access.redhat.com/openshift3/registry-console')
     expected_packages = set([])
-    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
-                     'redhat.com/umb/_static/img/icons/metaxor.png')
+    expected_icon = '/umb/_static/img/icons/metaxor.png'
 
     msg = {
         "username": None,
@@ -208,8 +205,7 @@ class TestMetaXORStrMessage(fedmsg.tests.test_meta.Base):
     expected_subti = ('Non dictionary message')
     expected_link = None
     expected_packages = set([])
-    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
-                     'redhat.com/umb/_static/img/icons/metaxor.png')
+    expected_icon = '/umb/_static/img/icons/metaxor.png'
 
     msg = {
         "username": None,
@@ -256,8 +252,7 @@ class TestMetaXORBadMessage(fedmsg.tests.test_meta.Base):
     expected_link = None
     expected_packages = set()
     expected_objects = set()
-    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
-                     'redhat.com/umb/_static/img/icons/metaxor.png')
+    expected_icon = '/umb/_static/img/icons/metaxor.png'
 
     msg = {
         "username": None,
@@ -304,8 +299,7 @@ class TestMetaXORcontainerRepositoryInsert(fedmsg.tests.test_meta.Base):
     expected_link = ('https://access.redhat.com/containers/#/'
                      'registry.access.redhat.com/rhel7/rhel')
     expected_objects = {'rhel7/rhel'}
-    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
-                     'redhat.com/umb/_static/img/icons/metaxor.png')
+    expected_icon = '/umb/_static/img/icons/metaxor.png'
 
     msg = {
         'username': None,
@@ -368,8 +362,7 @@ class TestMetaXORcontainerRepositoryUpdate(fedmsg.tests.test_meta.Base):
     expected_link = ('https://access.redhat.com/containers/#/'
                      'registry.access.redhat.com/rhel7/rhel')
     expected_objects = {'rhel7/rhel'}
-    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
-                     'redhat.com/umb/_static/img/icons/metaxor.png')
+    expected_icon = '/umb/_static/img/icons/metaxor.png'
 
     msg = {
         'username': None,
@@ -429,8 +422,7 @@ class TestMetaXORnternalRefreshRepo(fedmsg.tests.test_meta.Base):
     expected_subti = ('Repository update (2) requested by metaxor - '
                       'jboss-datagrid-7/datagrid72-openshift')
     expected_objects = set(['jboss-datagrid-7/datagrid72-openshift'])
-    expected_icon = ('https://datagrepper-prod-datanommer.int.open.paas.'
-                     'redhat.com/umb/_static/img/icons/metaxor.png')
+    expected_icon = '/umb/_static/img/icons/metaxor.png'
     expected_usernames = {'metaxor'}
 
     msg = {

--- a/fedmsg_meta_umb/tests/test_odcs.py
+++ b/fedmsg_meta_umb/tests/test_odcs.py
@@ -26,9 +26,7 @@ class TestODCSStateChange(fedmsg.tests.test_meta.Base):
     expected_link = (
         'http://odcs.host.stage.eng.bos.redhat.com/'
         'composes/latest-odcs-185-1/compose/Temporary/odcs-185.repo')
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/odcs.png')
+    expected_icon = '/umb/_static/img/icons/odcs.png'
     expected_usernames = set(['osbs'])
 
     msg = {

--- a/fedmsg_meta_umb/tests/test_resultsdb.py
+++ b/fedmsg_meta_umb/tests/test_resultsdb.py
@@ -32,9 +32,7 @@ class TestResultsDBNewGoodResult(fedmsg.tests.test_meta.Base):
     expected_agent = None
     expected_usernames = set([])
     expected_packages = set(['foo'])
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/resultsdb.png')
+    expected_icon = '/umb/_static/img/icons/resultsdb.png'
 
     msg = {
         "timestamp": 1529352189.0,
@@ -103,9 +101,7 @@ class TestLegacyResultsDBNewGoodResult(fedmsg.tests.test_meta.Base):
     expected_agent = None
     expected_usernames = set([])
     expected_packages = set(['qpid-dispatch'])
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/resultsdb.png')
+    expected_icon = '/umb/_static/img/icons/resultsdb.png'
 
     msg = {
         "headers": {
@@ -154,9 +150,7 @@ class TestLegacyResultsDBNewMalformedResult(fedmsg.tests.test_meta.Base):
     expected_agent = None
     expected_usernames = set([])
     expected_packages = set([])
-    expected_icon = (
-        'https://datagrepper-prod-datanommer.int.open.paas.redhat.com/'
-        'umb/_static/img/icons/resultsdb.png')
+    expected_icon = '/umb/_static/img/icons/resultsdb.png'
 
     msg = {
         "headers": {


### PR DESCRIPTION
Use links relative to the current hostname, rather than absolute URLs.