### PR TITLE
Add pub task id to robosignatory subtitle

### DIFF
--- a/fedmsg_meta_umb/robosignatory.py
+++ b/fedmsg_meta_umb/robosignatory.py
@@ -33,7 +33,7 @@ class RobosignatoryProcessor(BaseProcessor):
 
     def subtitle(self, msg, **config):
         if msg['topic'].endswith('robosignatory.container.sign'):
-            tmpl = self._("robosignatory's attempt to sign the {repo} "
-                          "container with {sig_key_id} was met "
-                          "with {signing_status}")
+            tmpl = self._("attempt to sign the {repo} container in pub task "
+                          "{pub_task_id} with {sig_key_id} was met with "
+                          "{signing_status}")
             return tmpl.format(**msg['msg'])

--- a/fedmsg_meta_umb/tests/test_robosignatory.py
+++ b/fedmsg_meta_umb/tests/test_robosignatory.py
@@ -28,9 +28,9 @@ class TestRobosignatoryContainerSign(fedmsg.tests.test_meta.Base):
     """
     expected_title = "robosignatory.container.sign"
     expected_subti = (
-        "robosignatory's attempt to sign the redhat-e2e-container-e2e-"
-        "container-test-product container with F21541EB was met with "
-        "success")
+        "attempt to sign the redhat-e2e-container-e2e-container-test-product "
+        "container in pub task 135422 with F21541EB was met with success")
+
     msg = {
         "headers": {
             "content-type": "text/plain",


### PR DESCRIPTION
Often times when debugging, a pub task id was given. Adding that to
the subtitle makes tracking down the related messages easier. Also
remove robosignatory from subtitle since it's already in the topic