### PR TITLE
add missing add_doc() calls to test suites

### DIFF
--- a/fedmsg_meta_umb/tests/test_ci.py
+++ b/fedmsg_meta_umb/tests/test_ci.py
@@ -17,9 +17,10 @@
 # Authors: Yukin Chan <yuqchen@redhat.com>
 
 import fedmsg.tests.test_meta
+from .common import add_doc
 
 class TestCIComplete(fedmsg.tests.test_meta.Base):
-    """ `Engineering CI Automation System performs tests to ensure the quality
+    """Engineering CI Automation System performs tests to ensure the quality
     of virtualization packages automatically.
 
     Messages (like the example given here) are published when an **CI**
@@ -95,3 +96,6 @@ class TestCIComplete(fedmsg.tests.test_meta.Base):
     expected_subti = 'Test job for libvirt-4.5.0-1.el7 complete'
     expected_packages = set(['libvirt'])
     expected_icon = '_static/img/icons/jenkins.png'
+
+
+add_doc(locals())

--- a/fedmsg_meta_umb/tests/test_cips.py
+++ b/fedmsg_meta_umb/tests/test_cips.py
@@ -17,6 +17,7 @@
 # Authors: Gowrishankar Rajaiyan <grajaiya@redhat.com>
 
 import fedmsg.tests.test_meta
+from .common import add_doc
 
 
 class TestLegacyTestMessage(fedmsg.tests.test_meta.Base):
@@ -302,3 +303,6 @@ class TestCIPSComplete(fedmsg.tests.test_meta.Base):
             "xunit": ""
         }
     }
+
+
+add_doc(locals())

--- a/fedmsg_meta_umb/tests/test_freshmaker.py
+++ b/fedmsg_meta_umb/tests/test_freshmaker.py
@@ -17,6 +17,7 @@
 # Authors:  Chenxiong Qi <cqi@redhat.com>
 
 import fedmsg.tests.test_meta
+from .common import add_doc
 
 
 class TestManualRebuild(fedmsg.tests.test_meta.Base):
@@ -350,3 +351,6 @@ class TestAllBuildsDone(fedmsg.tests.test_meta.Base):
         "topic": "/topic/VirtualTopic.eng.freshmaker.event.state.changed",
         "username": None,
     }
+
+
+add_doc(locals())

--- a/fedmsg_meta_umb/tests/test_jira.py
+++ b/fedmsg_meta_umb/tests/test_jira.py
@@ -17,6 +17,7 @@
 # Authors:  Stanislav Ochotnicky <sochotnicky@redhat.com>
 
 import fedmsg.tests.test_meta
+from .common import add_doc
 
 class TestJIRAIssueCreate(fedmsg.tests.test_meta.Base):
     """JIRA is issue tracking system
@@ -676,3 +677,6 @@ class TestJIRAIssueMissingKey(fedmsg.tests.test_meta.Base):
             }
         }
     }
+
+
+add_doc(locals())

--- a/fedmsg_meta_umb/tests/test_odcs.py
+++ b/fedmsg_meta_umb/tests/test_odcs.py
@@ -17,6 +17,7 @@
 # Authors:  Ralph Bean <rbean@redhat.com>
 
 import fedmsg.tests.test_meta
+from .common import add_doc
 
 
 class TestODCSStateChange(fedmsg.tests.test_meta.Base):
@@ -70,3 +71,6 @@ class TestODCSStateChange(fedmsg.tests.test_meta.Base):
             "event": "state-changed"
         }
     }
+
+
+add_doc(locals())

--- a/fedmsg_meta_umb/tests/test_tower.py
+++ b/fedmsg_meta_umb/tests/test_tower.py
@@ -17,6 +17,7 @@
 # Authors:  Ales Raszka <araszka@redhat.com>
 
 import fedmsg.tests.test_meta
+from .common import add_doc
 
 class TestTower(fedmsg.tests.test_meta.Base):
     """
@@ -119,3 +120,6 @@ class TestTowerUnknownMessage(fedmsg.tests.test_meta.Base):
         "source_version": "0.9.1",
         "msg": "Bad message format"
     }
+
+
+add_doc(locals())


### PR DESCRIPTION
This will ensure all test suites are included in the auto-generated documentation.

Also remove a rogue back-quote from test_ci.py.