### PR TITLE
Handle inconsistent IDs in Snitch messages

### DIFF
--- a/fedmsg_meta_umb/snitch.py
+++ b/fedmsg_meta_umb/snitch.py
@@ -39,14 +39,16 @@ class SnitchProcessor(BaseProcessor):
         if not isinstance(inner_msg, dict):
             return "Unknown message format"
 
+        obj_id = inner_msg["entityData"]["_id"]
+        if isinstance(obj_id, dict) and obj_id.get("$oid"):
+            obj_id = obj_id.get("$oid")
         data = {
             "entityData": inner_msg["entityData"],
             "entityName": inner_msg["entityName"],
             "operationType": headers["operationType"],
+            "_id": obj_id,
         }
 
-        template = self._(
-            "New DB event ({operationType}): {entityName} - {entityData[_id][$oid]}"
-        )
+        template = self._("New DB event ({operationType}): {entityName} - {_id}")
 
         return template.format(**data)

--- a/fedmsg_meta_umb/tests/test_snitch.py
+++ b/fedmsg_meta_umb/tests/test_snitch.py
@@ -77,4 +77,61 @@ class TestSnitch(fedmsg.tests.test_meta.Base):
     }
 
 
+class TestSnitch_id_as_string(fedmsg.tests.test_meta.Base):
+    """
+    Simple parser of Snitch messages
+    """
+
+    expected_title = "snitch"
+    expected_subti = "New DB event (replace): containerImage - foo"
+    expected_icon = "_static/img/icons/snitch.png"
+
+    msg = {
+        "i": 0,
+        "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-46538-1578341806859-3:541553:0:0:1",
+        "topic": "/topic/VirtualTopic.eng.snitch",
+        "timestamp": 1578902763.0,
+        "certificate": None,
+        "signature": None,
+        "username": None,
+        "crypto": None,
+        "msg": {
+            "entityData": {
+                "@mongoHidden": {"docver": [{"$oid": "5e1c24e8dd19c77896f587d4"}]},
+                "_id": "foo",
+                "architecture": "arm64",
+                "certifications#": 0,
+                "certified": False,
+                "content_sets": [],
+                "content_sets#": 0,
+                "cpe_ids#": 0,
+                "cpe_ids_rh_base_images#": 0,
+                "createdBy": "metaxor",
+                "creationDate": {"$date": 1578627911612},
+            },
+            "entityName": "containerImage",
+        },
+        "headers": {
+            "JMSXUserID": "msg-snitch",
+            "JMS_AMQP_MESSAGE_FORMAT": "0",
+            "JMS_AMQP_NATIVE": "false",
+            "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+            "amq6100_originalDestination": "topic://VirtualTopic.eng.snitch",
+            "correlation-id": "6b37e9b3-2c2d-4b3b-a2c1-26521f75b494",
+            "database": "data",
+            "destination": "/topic/VirtualTopic.eng.snitch",
+            "entityName": "containerImage",
+            "expires": "0",
+            "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-465383:541553:0:0:1",
+            "operationType": "replace",
+            "original-destination": "/topic/VirtualTopic.eng.snitch",
+            "priority": "4",
+            "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+            "timestamp": "0",
+        },
+        "source_name": "datanommer",
+        "source_version": "0.9.1",
+    }
+
+
 add_doc(locals())


### PR DESCRIPTION
Snitch produces messages based on MongoDB data. We found out that _id
fields in database are inconsistent and contains mix of strings and
ObjectId.

This commit handles both types of Snitch messages.