### PR TITLE
rpmdiff: reference local Errata Tool icon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
- - "3.7"
- - "3.8"
-matrix:
+  - "3.8"
+  - "3.9"
+jobs:
   include:
-    - python: "3.7"
+    - python: "3.9"
       env: TOXENV=flake8
-    - python: "3.7"
+    - python: "3.9"
       env: TOXENV=docs
 install: pip install tox-travis codecov
 script: tox -- --with-coverage --cover-branches --cover-package=fedmsg_meta_umb

--- a/fedmsg_meta_umb/rpmdiff.py
+++ b/fedmsg_meta_umb/rpmdiff.py
@@ -24,11 +24,10 @@ class RPMDiffProcessor(BaseProcessor):
 
     __name__ = 'rpmdiff'
     __description__ = 'the rpmdiff analysis system'
-    __link__ = 'https://rpmdiff.engineering.redhat.com'
-    __docs__ = 'https://mojo.redhat.com/docs/DOC-1085683'
+    __link__ = 'https://rpmdiff.engineering.redhat.com/'
+    __docs__ = 'https://docs.engineering.redhat.com/display/EXD/rpmdiff'
     __obj__ = 'RPMDiff Analysis System'
-    __icon__ = ('https://errata.devel.redhat.com/assets/'
-                'images/erratatool18.png')
+    __icon__ = '_static/img/icons/erratatool50.png'
 
     def title(self, msg, **config):
         return msg['topic'].split('.', 2)[-1]

--- a/fedmsg_meta_umb/tests/test_rpmdiff.py
+++ b/fedmsg_meta_umb/tests/test_rpmdiff.py
@@ -32,8 +32,8 @@ class TestRPMDiffComparisonStart(fedmsg.tests.test_meta.Base):
                       '3.6.65.1-1.git.0.1f50797.el7)')
     expected_link = 'https://rpmdiff.engineering.redhat.com/run/94269/'
     expected_packages = set(['openshift-ansible'])
-    expected_icon = ('https://errata.devel.redhat.com/assets/'
-                     'images/erratatool18.png')
+    expected_icon = '_static/img/icons/erratatool50.png'
+
     msg = {
         "i": 0,
         "msg": {
@@ -67,8 +67,8 @@ class TestRPMDiffAnalysisCompleted(fedmsg.tests.test_meta.Base):
                       '.git.0.1a149c1.el7 is completed')
     expected_link = 'https://rpmdiff.engineering.redhat.com/run/94268/'
     expected_packages = set(['openshift-ansible'])
-    expected_icon = ('https://errata.devel.redhat.com/assets/'
-                     'images/erratatool18.png')
+    expected_icon = '_static/img/icons/erratatool50.png'
+
     msg = {
         "username": None,
         "i": 0,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py{37,38},docs
+envlist = flake8,py{38,39},docs
 downloadcache = {toxworkdir}/_download/
 
 [testenv]


### PR DESCRIPTION
The Errata Tool icon is no longer available at the URL being used by
the rpmdiff processor. Replace it with a reference to a local copy.

Also update the docs link to point to the EXD Catalog. The Mojo
page is no longer available.