### PR TITLE
pub: reference local Errata Tool icon

### DIFF
--- a/fedmsg_meta_umb/pub.py
+++ b/fedmsg_meta_umb/pub.py
@@ -24,11 +24,10 @@ class PubProcessor(BaseProcessor):
 
     __name__ = 'pub'
     __description__ = 'the software publication system'
-    __link__ = 'https://pub.devel.redhat.com'
+    __link__ = 'https://pub.devel.redhat.com/'
     __docs__ = 'https://pub.devel.redhat.com/pub/docs/index.html'
     __obj__ = 'Publish Events'
-    __icon__ = ('https://errata.devel.redhat.com/assets/'
-                'images/erratatool18.png')
+    __icon__ = '_static/img/icons/erratatool50.png'
 
     def title(self, msg, **config):
         return msg['topic'].split('.', 2)[-1]

--- a/fedmsg_meta_umb/tests/test_pub.py
+++ b/fedmsg_meta_umb/tests/test_pub.py
@@ -34,8 +34,8 @@ class TestPubPushStop(fedmsg.tests.test_meta.Base):
     expected_usernames = set(['errata'])
     expected_agent = 'errata'
     # TODO - pub needs an icon to be cool...
-    expected_icon = ('https://errata.devel.redhat.com/assets/'
-                     'images/erratatool18.png')
+    expected_icon = '_static/img/icons/erratatool50.png'
+
     msg = {
         "username": None,
         "i": 0,
@@ -103,8 +103,8 @@ class TestPubPushFail(fedmsg.tests.test_meta.Base):
     expected_packages = set([])
     expected_usernames = set(['rhartman', 'errata'])
     expected_agent = 'rhartman'
-    expected_icon = ('https://errata.devel.redhat.com/assets/'
-                     'images/erratatool18.png')
+    expected_icon = '_static/img/icons/erratatool50.png'
+
     msg = {
         "username": None,
         "i": 0,
@@ -182,8 +182,8 @@ class TestPubPushStart(fedmsg.tests.test_meta.Base):
     expected_packages = set([])
     expected_usernames = set(['lismith'])
     expected_agent = 'lismith'
-    expected_icon = ('https://errata.devel.redhat.com/assets/'
-                     'images/erratatool18.png')
+    expected_icon = '_static/img/icons/erratatool50.png'
+
     msg = {
         "username": None,
         "i": 0,
@@ -248,8 +248,8 @@ class TestPubContainerSign(fedmsg.tests.test_meta.Base):
                       "e2e-container/e2e-container-test-product "
                       "was signed with key f21541eb in cdn-docker-stage-qa")
     expected_link = "http://pub.devel.redhat.com/pub/task/10908/"
-    expected_icon = ('https://errata.devel.redhat.com/assets/'
-                     'images/erratatool18.png')
+    expected_icon = '_static/img/icons/erratatool50.png'
+
     msg = {
         "username": None,
         "i": 0,


### PR DESCRIPTION
The Errata Tool icon is no longer available at the URL being used by
the pub processor. Replace it with a reference to a local copy.