### PR TITLE
set safe.directory so git will read files owned by a different user

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -10,5 +10,6 @@ tarxz: tarball
 	xz dist/*.tar
 
 srpm: tarxz
+	git config --global safe.directory $(PWD)
 	sed -i -e "s/^Release:.*/Release:        0.$$(date +%s).git$$(git log -1 --pretty=format:%h)%{?dist}/" *.spec
 	rpmbuild --define "_sourcedir dist" --define "_srcrpmdir $(outdir)" -bs *.spec


### PR DESCRIPTION
The user running the git command is different than the user that owns the git checkout
because the Makefile is run inside a mock environment, with the git checkout bind-mounted
into it. `git log` is used to include the commit hash in the srpm `Release` value, but Git
refuses to read any files owned by a different user unless safe.checkout is set.