### PR TITLE
Support Python 3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .eggs
 *.egg-info
 .tox
+.coverage*
 htmldocs
 doc/topics.rst

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 cloud_sptheme
 nose
-fedmsg
+fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
 mako

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,3 @@
 cloud_sptheme
-nose
 fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
 mako

--- a/python-fedmsg-meta-umb.spec
+++ b/python-fedmsg-meta-umb.spec
@@ -12,7 +12,6 @@ Source0:        %{srcname}-%{version}.tar.xz
 
 BuildArch:      noarch
 BuildRequires:  python3-devel
-BuildRequires:  python3-nose
 BuildRequires:  python3-fedmsg
 BuildRequires:  python3-mako
 BuildRequires:  python3-cloud-sptheme

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ f.close()
 setup_requires = [
 ]
 install_requires = [
-    'fedmsg',
+    'fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop',
 ]
 tests_require = [
     'nose',

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,8 @@ long_description = f.read().strip()
 long_description = long_description.split('split here', 1)[1]
 f.close()
 
-setup_requires = [
-]
 install_requires = [
     'fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop',
-]
-tests_require = [
-    'nose',
 ]
 
 entry_points = {
@@ -74,10 +69,7 @@ setup(
     author_email='mikeb@redhat.com',
     url='https://github.com/release-engineering/fedmsg_meta_umb/',
     license='LGPLv2+',
-    setup_requires=setup_requires,
     install_requires=install_requires,
-    tests_require=tests_require,
-    test_suite='nose.collector',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,15 @@ deps =
     fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
     coverage
 commands =
-    python -m unittest {posargs}
+    coverage run -m unittest {posargs}
+    coverage report
+
+[coverage:run]
+branch = true
+
+[coverage:report]
+show_missing = true
+skip_empty = true
 
 [testenv:flake8]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ show_missing = true
 skip_empty = true
 
 [testenv:flake8]
+skip_install = true
 deps=
     flake8
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ downloadcache = {toxworkdir}/_download/
 
 [testenv]
 deps =
-    fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
     coverage
 commands =
     coverage run -m unittest {posargs}
@@ -26,8 +25,6 @@ commands=
 
 [testenv:docs]
 deps =
-    cloud_sptheme
-    fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
-    mako
+    -r doc/requirements.txt
 commands =
     sphinx-build doc/ htmldocs/

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = flake8,py{38,39},docs
+envlist = flake8,py312,docs
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
 deps =
-    fedmsg
+    fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
     nose
     coverage
 commands =
@@ -21,7 +21,7 @@ commands=
 deps =
     cloud_sptheme
     nose
-    fedmsg
+    fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
     mako
 commands =
     sphinx-build doc/ htmldocs/

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,9 @@ downloadcache = {toxworkdir}/_download/
 [testenv]
 deps =
     fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
-    nose
     coverage
 commands =
-    nosetests {posargs}
+    python -m unittest {posargs}
 
 [testenv:flake8]
 deps=
@@ -20,7 +19,6 @@ commands=
 [testenv:docs]
 deps =
     cloud_sptheme
-    nose
     fedmsg @ git+https://github.com/fedora-infra/fedmsg.git@develop
     mako
 commands =


### PR DESCRIPTION
`nose` is not supported under Python 3.12, switch to running tests with `unittest`.
Use the `develop` branch of `fedmsg` directly, since Python 3.12 support was recently added there but has not made it into a release.
Report test coverage.